### PR TITLE
Load dataset options from metadata table

### DIFF
--- a/app_code/dataset_info.csv
+++ b/app_code/dataset_info.csv
@@ -1,0 +1,6 @@
+id,short_name,title,image,citation,link,featured
+tmkmh,TMKMH,TMKMH integrated dataset,TMKMH_img.png,, ,TRUE
+tabib,"Tabib et al.","Tabib et al. 2021",Tabib_img.png,"Tabib, T., Huang, M., Morse, N., Papazoglou, A., Behera, R., Jia, M., Bulik, M., Monier, D. E., Benos, P. v., Chen, W., Domsic, R., & Lafyatis, R. (2021). Myofibroblast transcriptome indicates SFRP2hi fibroblast progenitors in systemic sclerosis skin. Nature Communications, 12(1), 4384.","https://www.nature.com/articles/s41467-021-24607-6",FALSE
+gur,"Gur et al.","Gur et al. 2022",Gur_img.png,,,FALSE
+ma,"Ma et al.","Ma et al. 2024",Ma_img.png,,,FALSE
+khanna,"Khanna et al","Khanna et al. 2022",Khanna_img.png,,,FALSE

--- a/app_code/server.R
+++ b/app_code/server.R
@@ -18,69 +18,18 @@ server <- function(input, output,session) {
   
   
   # ########################## Starting page #######################
-  output$Tabib_img <- renderImage({
+  lapply(dataset_info$id, function(id) {
+    output[[paste0(id, "_img")]] <- renderImage({
+      screen_width <- input$dimension[1]
+      img_path <- file.path("imgs", dataset_info$image[dataset_info$id == id])
+      is_featured <- dataset_info$featured[dataset_info$id == id]
+      image_width <- if (is_featured) screen_width * 0.9 else (screen_width / 2) * 0.9
+      list(src = img_path, width = paste0(image_width, "px"))
+    }, deleteFile = FALSE)
 
-    screen_width <- input$dimension[1]
-    image_width <- (screen_width / 2)*0.9
-
-    list(src = "imgs/Tabib_img.png",
-         width = paste0(image_width, "px"))
-  }, deleteFile = FALSE)
-
-  output$Gur_img <- renderImage({
-
-    screen_width <- input$dimension[1]
-    image_width <- (screen_width / 2)*0.9
-
-    list(src = "imgs/Gur_img.png",
-         width = paste0(image_width, "px"))
-  }, deleteFile = FALSE)
-
-  output$Ma_img <- renderImage({
-
-    screen_width <- input$dimension[1]
-    image_width <- (screen_width / 2)*0.9
-
-    list(src = "imgs/Ma_img.png",
-         width = paste0(image_width, "px"))
-  }, deleteFile = FALSE)
-
-  output$Khanna_img <- renderImage({
-
-    screen_width <- input$dimension[1]
-    image_width <- (screen_width / 2)*0.9
-
-    list(src = "imgs/Khanna_img.png",
-         width = paste0(image_width, "px"))
-  }, deleteFile = FALSE)
-  
-  output$TMKMH_img <- renderImage({
-    image_width <- input$dimentions[1]*0.9
-    list(src = "imgs/TMKMH_img.png",
-      width = paste0(image_width,"px")
-    )
-  },
-  deleteFile = FALSE)
-  
-  
-  observeEvent(input$explore_Tabib,{
-    updateSelectInput(session, "study", selected = "tabib")
-  })
-  
-  observeEvent(input$explore_Gur,{
-    updateSelectInput(session, "study", selected = "gur")
-  })
-  
-  observeEvent(input$explore_Ma,{
-    updateSelectInput(session, "study", selected = "ma")
-  })
-  
-  observeEvent(input$explore_Khanna,{
-    updateSelectInput(session, "study", selected = "khanna")
-  })
-  
-  observeEvent(input$explore_tmkmh,{
-    updateSelectInput(session, "study", selected = "tmkmh")
+    observeEvent(input[[paste0("explore_", id)]], {
+      updateSelectInput(session, "study", selected = id)
+    })
   })
   
   ################################## Explore page #################################

--- a/app_code/setup.R
+++ b/app_code/setup.R
@@ -2,7 +2,8 @@ inDir <- "/srv/shiny-server/atlas/data/"
 DE_dir <- "DE_dfs/"
 cat("Working directory is:", getwd(), "\n", file = stderr())
 
-
+# Read dataset metadata used for UI construction
+dataset_info <- read.csv("dataset_info.csv", stringsAsFactors = FALSE)
 
 # Define the file paths for your datasets
 dataset_files <- list(

--- a/app_code/ui.R
+++ b/app_code/ui.R
@@ -85,21 +85,10 @@ ui <- page_navbar(
         dimension = [window.innerWidth, window.innerHeight];
         Shiny.onInputChange("dimension", dimension);
       });
-      // Function to switch to the Explore tab
-      $("#explore_Tabib").on("click", function() {
-        $("a[data-value=\'Explore\']").tab("show");
-      });$("#explore_Gur").on("click", function() {
+      // Switch to the Explore tab when any explore button is clicked
+      $("button[id^='explore_']").on("click", function() {
         $("a[data-value=\'Explore\']").tab("show");
       });
-      $("#explore_Ma").on("click", function() {
-        $("a[data-value=\'Explore\']").tab("show");
-      });
-      $("#explore_tmkmh").on("click", function() {
-        $("a[data-value=\'Explore\']").tab("show");
-      });
-      $("#explore_Khanna").on("click", function() {
-        $("a[data-value=\'Explore\']").tab("show");
-});
     });
   ')
   ),
@@ -108,43 +97,38 @@ ui <- page_navbar(
   title = "SSc cell atlas",
   id = "nav_page",
   nav_panel("Get started",
-            card(full_screen = TRUE,
-                 card_header("TMKMH integrated dataset"),
-                 actionButton("explore_tmkmh","Explore"),
-                 imageOutput("TMKMH_img")
-                 
-                 )
-            ,
-            layout_column_wrap(
-              width = 1/4,
-
-              #Tabib
-              card(full_screen = TRUE,
-                   card_header("Tabib et al. 2021"),
-                   actionButton("explore_Tabib","Explore"),
-                   imageOutput("Tabib_img"),
-                   a(href = "https://www.nature.com/articles/s41467-021-24607-6",
-                     p(strong("Tabib, T., Huang, M., Morse, N., Papazoglou, A., Behera, R., Jia, M., Bulik, M., Monier, D. E., Benos, P. v., Chen, W., Domsic, R., & Lafyatis, R. (2021)."),"Myofibroblast transcriptome indicates SFRP2hi fibroblast progenitors in systemic sclerosis skin. Nature Communications, 12(1), 4384."),
-                     style = "color:grey", target="_blank")
-              ),
-              # Gur
-              card(full_screen = TRUE,
-                   card_header("Gur et al. 2022"),
-                   actionButton("explore_Gur","Explore"),
-                   imageOutput("Gur_img")),
-
-              # Ma
-              card(full_screen = TRUE,
-                   card_header("Ma et al. 2024"),
-                   actionButton("explore_Ma","Explore"),
-                   imageOutput("Ma_img")),
-
-              # Clark
-              card(full_screen = TRUE,
-                   card_header("Khanna et al. 2022"),
-                   actionButton("explore_Khanna","Explore"),
-                   imageOutput("Khanna_img")),
-
+            {
+              featured <- dataset_info[dataset_info$featured, ][1,]
+              card(
+                full_screen = TRUE,
+                card_header(featured$title),
+                actionButton(paste0("explore_", featured$id), "Explore"),
+                imageOutput(paste0(featured$id, "_img"))
+              )
+            },
+            do.call(
+              layout_column_wrap,
+              c(
+                list(width = 1/4),
+                lapply(
+                  split(dataset_info[!dataset_info$featured, ],
+                        seq_len(nrow(dataset_info[!dataset_info$featured, ]))),
+                  function(ds) {
+                    card(
+                      full_screen = TRUE,
+                      card_header(ds$title),
+                      actionButton(paste0("explore_", ds$id), "Explore"),
+                      imageOutput(paste0(ds$id, "_img")),
+                      if (!is.na(ds$link) && nzchar(ds$link))
+                        a(
+                          href = ds$link,
+                          p(ds$citation),
+                          style = "color:grey", target = "_blank"
+                        )
+                    )
+                  }
+                )
+              )
             )
   ),
   
@@ -156,14 +140,10 @@ ui <- page_navbar(
               sidebar = sidebar(
                 title = "Select dataset and genes",
                 position = "left",
-                selectInput("study","Select study to explore",
-                            choices = c(
-                              "TMKMH" = "tmkmh",
-                              "Tabib et al." = "tabib",
-                              "Gur et al." = "gur",
-                              "Ma et al." = "ma",
-                              "Khanna et al" = "khanna"
-                            )),
+                selectInput(
+                  "study", "Select study to explore",
+                  choices = setNames(dataset_info$id, dataset_info$short_name)
+                ),
 
                 
                 conditionalPanel(


### PR DESCRIPTION
## Summary
- Centralize dataset metadata in `dataset_info.csv` and read it during setup
- Generate starting page cards and dataset selector dynamically from metadata
- Render dataset images and explore-button observers programmatically

## Testing
- `R -q -e "lintr::lint_dir('app_code')"` *(failed: command not found)*
- `sudo apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f7d6f67148330aaab90e3b1022c07