### PR TITLE
fix: feature plot download button

### DIFF
--- a/app_code/server.R
+++ b/app_code/server.R
@@ -782,40 +782,17 @@ server <- function(input, output, session) {
   })
 
   output$dld_feature_plot <- downloadHandler(
-    filename = function(){
-      generated_filename <- paste0("featureplot.",input$file_type_1)
-      print(paste("Generated filename:", generated_filename))
-      return(generated_filename)  # Ensure the filename is returned
-      "featureplot.pdf"
+    filename = function() {
+      paste0("featureplot.", input$file_type_1)
     },
-    content = function(file){
-      filetype <- tools::file_ext(file)
+    content = function(file) {
+      fmt <- input$file_type_1
       if (sidebar_inputs$feature_type() == "Genes") {
-        p <- plot(featureplot_plot_gene())
+        p <- featureplot_plot_gene()
       } else {
-        p <- plot(featureplot_plot_pathway())
+        p <- featureplot_plot_pathway()
       }
-      
-      ggsave(file,plot = p, device = filetype)
-      
-    
-      # 
-      # if (filetype == "png"){
-      #   png(file)
-      #   print("here")
-      #   p
-      #   dev.off()
-      # }else if (filetype == "pdf"){
-      #   pdf(file)
-      # }else if (filetype == "jpg"){
-      #   jpeg(file)
-      # }
-      png(file)
-      print("here")
-      p
-      dev.off()
-
-      print(paste("File type:", filetype))
+      ggsave(file, plot = p, device = fmt)
     }
   )
 


### PR DESCRIPTION
## Summary

- The download handler was reading the file format from Shiny's temp file path (which has no meaningful extension) instead of `input$file_type_1` — so the format was always empty/wrong
- A dead `png(file)` / `dev.off()` block after the `ggsave` call was running unconditionally and corrupting the output file
- Removed unnecessary `plot()` wrapper around ggplot objects (ggplot objects are passed directly to `ggsave`)

## Test plan

- [x] Select a gene, load the feature plot
- [x] Download as PNG — verify file opens correctly
- [x] Download as PDF — verify file opens correctly
- [x] Download as JPG — verify file opens correctly
- [ ] Repeat with a pathway selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)