### PR TITLE
Fix grouping in boxplot

### DIFF
--- a/app_code/server.R
+++ b/app_code/server.R
@@ -740,9 +740,10 @@ server <- function(input, output, session) {
           }
           
           plot_data <- FetchData(curr_obj, vars = c(feature_names, "Disease"), assay = assay_to_use) %>%
-            pivot_longer(cols = -Disease, names_to = "feature", values_to = "expression")
-          
-          ggplot(plot_data, aes(x = Disease, y = expression, fill = Disease)) +
+            mutate(cell_type = as.character(Idents(curr_obj))) %>%
+            pivot_longer(cols = -c(Disease, cell_type), names_to = "feature", values_to = "expression")
+
+          ggplot(plot_data, aes(x = cell_type, y = expression, fill = Disease)) +
             geom_boxplot(outlier.shape = NA) +
             scale_fill_manual(values = c("HC" = "#cb07a4ff", "SSc" = "#09b646ff")) +
             facet_wrap(~feature, scales = "free_y") +


### PR DESCRIPTION
fix: restore cell type grouping in box plot expression view

Box plot was grouping only by Disease on the x-axis, losing the cell type breakdown shown in violin plot
Fixed by fetching Idents(curr_obj) as cell_type and using it as the x-axis, with Disease as fill color — matching violin plot behavior
Test: Load a dataset → select 1–3 genes → toggle Vln→Box → verify boxes are grouped by cell type, colored by HC/SSc