### PR TITLE
feat: enable violin/box plot for Khanna dataset, colored by timepoint

### DIFF
--- a/app_code/config/dataset_details.json
+++ b/app_code/config/dataset_details.json
@@ -156,6 +156,7 @@
   },
   "khanna": {
     "comparison_type": "timepoint",
+    "comparison_column": "time_point",
     "comparison_label": "After vs Before Treatment",
     "data_levels": {
       "Full": "full",

--- a/app_code/server.R
+++ b/app_code/server.R
@@ -183,7 +183,20 @@ server <- function(input, output, session) {
   meta_df <- reactiveVal()
   # Holds the validated, parsed gene list after the user clicks "Apply Gene List"
   applied_gene_list <- reactiveVal(NULL)
-  
+
+  group_col <- reactive({
+    dataset_comparison_column[[sidebar_inputs$study()]]
+  })
+
+  group_colors <- reactive({
+    col <- group_col()
+    obj <- seurat_obj()
+    req(obj)
+    lvls <- levels(as.factor(obj@meta.data[[col]]))
+    default_palette <- c("#cb07a4ff", "#09b646ff", "#2196F3", "#FF9800")
+    setNames(default_palette[seq_along(lvls)], lvls)
+  })
+
   # Dynamic UI for comparison checkbox with appropriate label
   output$by_condition_checkbox <- renderUI({
     req(sidebar_inputs$study())
@@ -921,37 +934,37 @@ server <- function(input, output, session) {
           } else {
             "VAMcdf"
           }
-          VlnPlot(curr_obj, 
-                  features = feature_names, 
+          VlnPlot(curr_obj,
+                  features = feature_names,
                   assay = assay_to_use,
-                  split.by = "Disease", 
+                  split.by = group_col(),
                   split.plot = FALSE,
                   pt.size = 0,
-                  cols = c("HC" = "#cb07a4ff", "SSc" = "#09b646ff"))
+                  cols = group_colors())
         } else { # BoxPlot
           assay_to_use <- if (f_type == "Genes") {
             if ("SCT" %in% Assays(curr_obj)) "SCT" else "RNA"
           } else {
             "VAMcdf"
           }
-          
-          plot_data <- FetchData(curr_obj, vars = c(feature_names, "Disease"), assay = assay_to_use) %>%
+          grp <- group_col()
+          plot_data <- FetchData(curr_obj, vars = c(feature_names, grp), assay = assay_to_use) %>%
             mutate(cell_type = as.character(Idents(curr_obj))) %>%
-            pivot_longer(cols = -c(Disease, cell_type), names_to = "feature", values_to = "expression")
+            pivot_longer(cols = -c(all_of(grp), cell_type), names_to = "feature", values_to = "expression")
 
-          ggplot(plot_data, aes(x = cell_type, y = expression, fill = Disease)) +
+          ggplot(plot_data, aes(x = cell_type, y = expression, fill = .data[[grp]])) +
             geom_boxplot(outlier.shape = NA) +
-            scale_fill_manual(values = c("HC" = "#cb07a4ff", "SSc" = "#09b646ff")) +
+            scale_fill_manual(values = group_colors()) +
             facet_wrap(~feature, scales = "free_y") +
             theme_classic() +
             theme(axis.text.x = element_text(angle = 45, hjust = 1))
         }
       } else {
         # Show a dot plot for > 3 features by default
-        DotPlot(curr_obj, 
-                features = feature_names, 
-                cols = c("blue", "red"), 
-                split.by = "Disease")
+        DotPlot(curr_obj,
+                features = feature_names,
+                cols = c("blue", "red"),
+                split.by = group_col())
       }
     }
   })
@@ -962,18 +975,9 @@ server <- function(input, output, session) {
     "Please choose a gene."
   })
   
-  output$geneExpPlot_Khanna_msg <- renderText({
-    "Not applicable"
-  })
-
   output$exp_plot_UI <- renderUI({
     if (!is.null(gene_queried()) || !is.null(pathway_queried())) {
-      if(sidebar_inputs$study() == "khanna"){
-        textOutput("geneExpPlot_Khanna_msg")
-      }else{
-        plotOutput("geneExpPlot")
-      }
-      
+      plotOutput("geneExpPlot")
     } else {
       textOutput("geneExpPlot_msg")
     }

--- a/app_code/setup.R
+++ b/app_code/setup.R
@@ -36,11 +36,12 @@ data_level_choices <- list()
 dataset_comparison_type <- list()
 dataset_comparison_label <- list()
 dataset_metadata_file <- list()
+dataset_comparison_column <- list()
 
 # Populate lists based on dataset_meta and dataset_details
 for (i in 1:nrow(dataset_meta)) {
   dataset_id <- dataset_meta$id[i]
-  
+
   if (dataset_id %in% names(dataset_details)) {
     # If details are available in the JSON file, use them to build the data structures.
     dataset_files[[dataset_id]] <- dataset_details[[dataset_id]]$files
@@ -48,6 +49,7 @@ for (i in 1:nrow(dataset_meta)) {
     dataset_comparison_type[[dataset_id]] <- dataset_details[[dataset_id]]$comparison_type %||% DEFAULT_COMPARISON_TYPE
     dataset_comparison_label[[dataset_id]] <- dataset_details[[dataset_id]]$comparison_label %||% DEFAULT_COMPARISON_LABEL
     dataset_metadata_file[[dataset_id]] <- dataset_details[[dataset_id]]$files$meta %||% NULL
+    dataset_comparison_column[[dataset_id]] <- dataset_details[[dataset_id]]$comparison_column %||% "Disease"
   } else {
     # If no details are found for the dataset in the JSON file, fall back to a minimal default structure.
     # This ensures that all datasets listed in datasets.tsv are available in the app, even without a detailed configuration.
@@ -56,6 +58,7 @@ for (i in 1:nrow(dataset_meta)) {
     dataset_comparison_type[[dataset_id]] <- DEFAULT_COMPARISON_TYPE
     dataset_comparison_label[[dataset_id]] <- DEFAULT_COMPARISON_LABEL
     dataset_metadata_file[[dataset_id]] <- NULL
+    dataset_comparison_column[[dataset_id]] <- "Disease"
   }
 }
 


### PR DESCRIPTION
## Summary

- The Khanna dataset has no healthy controls, so the existing violin/box plot (which hardcodes `split.by = "Disease"` with HC/SSc colors) was entirely suppressed for this dataset with a "Not applicable" stub
- Adds a `comparison_column` config key to `dataset_details.json` (`"time_point"` for Khanna, defaults to `"Disease"` for all others)
- Adds `group_col` / `group_colors` reactives in `server.R` that look up the correct metadata column and derive colors dynamically from the Seurat object's actual factor levels
- Updates VlnPlot, BoxPlot, and DotPlot to use these reactives instead of hardcoded values
- Removes the Khanna-specific `exp_plot_UI` branch and the unused `geneExpPlot_Khanna_msg` output

## Test plan

- [ ] Select Khanna dataset (Full / Myeloid / Fibroblasts) → select 1–3 genes → violin plot should appear, split by `time_point` with two distinct colors
- [ ] Toggle to box plot for Khanna → same grouping and coloring
- [ ] Select >3 genes for Khanna → dot plot renders with `split.by = "time_point"`
- [ ] Switch to a non-Khanna dataset (e.g. Bos) → verify HC/SSc coloring still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)