### PR TITLE
feat: Violin/box expression-by-cluster plots in spatial tab

### DIFF
--- a/app_code/modules/spatial_unit.R
+++ b/app_code/modules/spatial_unit.R
@@ -1,8 +1,6 @@
 library(shiny)
 library(bslib)
 library(Seurat)
-library(ggplot2)
-library(tidyr)
 
 # ---------- MODULE UI ----------
 spatial_UI <- function(id) {

--- a/app_code/modules/spatial_unit.R
+++ b/app_code/modules/spatial_unit.R
@@ -153,19 +153,24 @@ spatial_server <- function(id, spat_obj = NULL, rds_path = NULL) {
     
     # ---- Expression by cluster/region plot ----
     group_by_col <- reactive({
-      switch(input$group_by,
-        "cluster"     = "seurat_clusters",
-        "Key_Regions" = "Key_Regions",
-        input$group_by
-      )
+      # Use the raw input$group_by value directly — it matches the metadata column
+      # name (the same value passed to SpatialDimPlot/DimPlot group.by).
+      # Fall back to the first metadata column if it somehow doesn't exist.
+      grp <- input$group_by
+      meta_cols <- colnames(obj()@meta.data)
+      if (!grp %in% meta_cols) {
+        # Try common alternatives
+        alts <- c("seurat_clusters", "ident", "orig.ident")
+        grp <- alts[alts %in% meta_cols][1]
+      }
+      grp
     })
 
     expr_plot_data <- reactive({
       req(obj(), length(input$feature) > 0)
       genes <- input$feature
       grp   <- group_by_col()
-      # Validate the grouping column exists
-      req(grp %in% colnames(obj()@meta.data))
+      req(!is.na(grp), grp %in% colnames(obj()@meta.data))
       df <- FetchData(obj(), vars = c(grp, genes))
       colnames(df)[1] <- "group"
       df$group <- factor(df$group)

--- a/app_code/modules/spatial_unit.R
+++ b/app_code/modules/spatial_unit.R
@@ -1,6 +1,8 @@
 library(shiny)
 library(bslib)
 library(Seurat)
+library(ggplot2)
+library(tidyr)
 
 # ---------- MODULE UI ----------
 spatial_UI <- function(id) {
@@ -21,6 +23,28 @@ spatial_UI <- function(id) {
     conditionalPanel(
       condition = paste0("input['", ns("samples"), "'] && input['", ns("samples"), "'].length > 0"),
       uiOutput(ns("sample_centric_grid"))
+    ),
+    # Expression by cluster/region
+    conditionalPanel(
+      condition = paste0("input['", ns("feature"), "'] && input['", ns("feature"), "'].length > 0"),
+      card(
+        card_header(
+          div(
+            class = "d-flex align-items-center justify-content-between w-100",
+            span("Expression by cluster / region"),
+            div(
+              class = "d-flex align-items-center gap-2",
+              radioButtons(
+                ns("expr_plot_type"), label = NULL,
+                choices = c("Violin" = "violin", "Box" = "box"),
+                selected = "violin", inline = TRUE
+              ),
+              downloadButton(ns("dld_expr"), "Download", class = "btn-sm")
+            )
+          )
+        ),
+        plotOutput(ns("expr_by_cluster"), height = 420)
+      )
     )
   )
 }
@@ -127,6 +151,76 @@ spatial_server <- function(id, spat_obj = NULL, rds_path = NULL) {
       do.call(layout_columns, c(list(col_widths = rep(6, length(cards))), cards))
     })
     
+    # ---- Expression by cluster/region plot ----
+    group_by_col <- reactive({
+      switch(input$group_by,
+        "cluster"     = "seurat_clusters",
+        "Key_Regions" = "Key_Regions",
+        input$group_by
+      )
+    })
+
+    expr_plot_data <- reactive({
+      req(obj(), length(input$feature) > 0)
+      genes <- input$feature
+      grp   <- group_by_col()
+      # Validate the grouping column exists
+      req(grp %in% colnames(obj()@meta.data))
+      df <- FetchData(obj(), vars = c(grp, genes))
+      colnames(df)[1] <- "group"
+      df$group <- factor(df$group)
+      if (length(genes) == 1) {
+        df$gene <- genes
+        colnames(df)[2] <- "expression"
+      } else {
+        df <- tidyr::pivot_longer(df, cols = -group, names_to = "gene", values_to = "expression")
+      }
+      df
+    })
+
+    expr_plot_reactive <- reactive({
+      req(expr_plot_data())
+      df   <- expr_plot_data()
+      grp_label <- switch(input$group_by,
+        "cluster"     = "Seurat cluster",
+        "Key_Regions" = "Key region",
+        input$group_by
+      )
+      p <- ggplot2::ggplot(df, ggplot2::aes(x = group, y = expression, fill = group))
+      if (isTRUE(input$expr_plot_type == "box")) {
+        p <- p + ggplot2::geom_boxplot(outlier.size = 0.4, outlier.alpha = 0.4)
+      } else {
+        p <- p +
+          ggplot2::geom_violin(scale = "width", trim = TRUE) +
+          ggplot2::geom_jitter(width = 0.15, size = 0.3, alpha = 0.25, show.legend = FALSE)
+      }
+      p <- p +
+        ggplot2::facet_wrap(~gene, scales = "free_y") +
+        ggplot2::labs(x = grp_label, y = "Normalized expression", fill = grp_label) +
+        ggplot2::theme_bw(base_size = 12) +
+        ggplot2::theme(
+          axis.text.x  = ggplot2::element_text(angle = 45, hjust = 1),
+          legend.position = "none",
+          strip.background = ggplot2::element_rect(fill = "#f0f0f0")
+        )
+      p
+    })
+
+    output$expr_by_cluster <- renderPlot({ expr_plot_reactive() })
+
+    output$dld_expr <- downloadHandler(
+      filename = function() {
+        genes <- paste(input$feature, collapse = "-")
+        paste0("expr_by_", input$group_by, "_", genes, ".png")
+      },
+      content = function(file) {
+        n_genes <- length(input$feature)
+        w <- max(7, 3.5 * ceiling(sqrt(n_genes)))
+        h <- max(5, 3   * ceiling(n_genes / ceiling(sqrt(n_genes))))
+        ggplot2::ggsave(file, expr_plot_reactive(), width = w, height = h, dpi = 150)
+      }
+    )
+
     observe({
       req(length(input$samples) > 0, default_pt_sizes())
       

--- a/app_code/modules/spatial_unit.R
+++ b/app_code/modules/spatial_unit.R
@@ -171,11 +171,18 @@ spatial_server <- function(id, spat_obj = NULL, rds_path = NULL) {
       genes <- input$feature
       grp   <- group_by_col()
       req(!is.na(grp), grp %in% colnames(obj()@meta.data))
-      df <- FetchData(obj(), vars = c(grp, genes))
+      # Set SCT as default so FetchData resolves gene names correctly
+      plot_obj <- obj()
+      DefaultAssay(plot_obj) <- "SCT"
+      df <- FetchData(plot_obj, vars = c(grp, genes))
+      # Drop any genes that FetchData couldn't find
+      found_genes <- intersect(genes, colnames(df))
+      req(length(found_genes) > 0)
+      df <- df[, c(grp, found_genes), drop = FALSE]
       colnames(df)[1] <- "group"
       df$group <- factor(df$group)
-      if (length(genes) == 1) {
-        df$gene <- genes
+      if (length(found_genes) == 1) {
+        df$gene <- found_genes
         colnames(df)[2] <- "expression"
       } else {
         df <- tidyr::pivot_longer(df, cols = -group, names_to = "gene", values_to = "expression")

--- a/app_code/ui.R
+++ b/app_code/ui.R
@@ -199,8 +199,8 @@ ui <- page_navbar(
                     choices = c("Seurat cluster" = "cluster",
                     "Key regions" =  "Key_Regions"),
                   selected = "cluster"),
-        selectizeInput(NS("sp1", "feature"), "Feature (Gene/pathway)",multiple = TRUE,
-        choices = NULL, options = list(placeholder = "Type to search…")),
+        selectizeInput(NS("sp1", "feature"), "Feature (Gene/pathway)", multiple = TRUE,
+        choices = NULL, options = list(placeholder = "Type to search…", maxItems = 6)),
         checkboxGroupInput(NS("sp1", "samples"),
                       "Select samples to view"
                     )


### PR DESCRIPTION
## Summary

Adds violin and box plots showing gene expression broken down by cluster or region directly below the tissue images in the Spatial data explorer tab.

## Changes

### pp_code/modules/spatial_unit.R
- New card appears automatically when a gene is selected (via conditionalPanel)
- **Violin / Box** radio toggle in the card header switches plot type
- **Download** button exports a correctly-sized PNG based on gene count
- group_by_col() maps the existing sidebar \group_by\ input to the actual Seurat metadata column (\seurat_clusters\ or \Key_Regions\)
- \FetchData()\ drives data retrieval; multi-gene panels use \	idyr::pivot_longer\ and are faceted with independent y-scales

### \pp_code/ui.R\
- Added \maxItems = 6\ to the spatial gene \selectizeInput\ to cap multi-gene selection

## Behaviour
- **Single gene** → single violin/box panel
- **Multi-gene (up to 6)** → facet grid, one panel per gene, each with its own y-axis scale
- **Group by** toggle (Seurat cluster / Key regions) updates the x-axis of the expression plot in sync with the spatial tissue plots