### PR TITLE
ci: pass ANTHROPIC_API_KEY to all deployments

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -84,6 +84,7 @@ jobs:
               --restart unless-stopped \
               -p "${PR_PORT}:3838" \
               -e SHINY_LOG_STDERR=1 \
+              -e ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
               -v /home/ubuntu/atlas/data:/srv/shiny-server/atlas/data:ro \
               -v "/home/ubuntu/atlas/pr_data/pr-${PR_NUM}:/srv/shiny-server/data" \
               -v "/home/ubuntu/atlas/pr_cache/pr-${PR_NUM}:/srv/shiny-server/atlas/app_cache" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,9 @@ jobs:
             echo "🛠 Building images with cache..."
             docker-compose build --pull
 
+            echo "🔐 Setting up environment..."
+            echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" > .env
+
             echo "🔐 Verifying port 80 is free..."
             if sudo lsof -ti:80 >/dev/null 2>&1; then
               echo "❌ Port 80 is still in use!"


### PR DESCRIPTION
- Production (deploy.yml): Pass API key via .env file to docker-compose
- PR deployments (deploy-pr.yml): Pass API key as env var to docker run
- Fixes 'API key not set' error in AI Assistant chat panel