### PR TITLE
Add CellChat visualization explorer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libglpk-dev \
     libjpeg-dev \
     libpng-dev \
+    libwebpmux3 \
     libuv1 \
     python3 python3-pip python3-venv \
     vim nano \
@@ -23,7 +24,7 @@ RUN pip install pandas
 RUN R -e 'install.packages(c("plotly", "igraph", "Seurat", "Matrix", "SeuratObject", "DT", "ggplot2", "dplyr", "stringr", "shiny", "shinymanager", "shinyWidgets", "bslib", "shinycssloaders", "bsicons", "VAM", "periscope2", "shinyjs", "tidyr", "DBI", "RSQLite", "jpeg", "png", "qs2", "BiocManager", "remotes"))' && \
     R -e 'BiocManager::install(c("ComplexHeatmap", "BiocNeighbors", "Biobase"), ask = FALSE, update = FALSE)' && \
     R -e 'remotes::install_github("jinworks/CellChat", dependencies = TRUE, upgrade = "never", force = TRUE)' && \
-    R -e 'stopifnot(requireNamespace("CellChat", quietly = TRUE))'
+    R -e 'stopifnot(requireNamespace("CellChat", quietly = TRUE)); library(ragg)'
 
 # Copy Shiny app code
 COPY ./app_code/ /srv/shiny-server/atlas/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install pandas
 
 # Install R packages
-RUN R -e 'install.packages(c("plotly", "igraph", "Seurat", "Matrix", "SeuratObject", "DT", "ggplot2", "dplyr", "stringr", "shiny", "shinymanager", "shinyWidgets", "bslib", "shinycssloaders", "bsicons", "VAM", "periscope2", "shinyjs", "tidyr", "DBI", "RSQLite", "jpeg", "png", "qs2"))'
+RUN R -e 'install.packages(c("plotly", "igraph", "Seurat", "Matrix", "SeuratObject", "DT", "ggplot2", "dplyr", "stringr", "shiny", "shinymanager", "shinyWidgets", "bslib", "shinycssloaders", "bsicons", "VAM", "periscope2", "shinyjs", "tidyr", "DBI", "RSQLite", "jpeg", "png", "qs2", "BiocManager", "remotes"))' && \
+    R -e 'BiocManager::install("ComplexHeatmap", ask = FALSE, update = FALSE)' && \
+    R -e 'remotes::install_github("jinworks/CellChat", dependencies = TRUE, upgrade = "never")'
 
 # Copy Shiny app code
 COPY ./app_code/ /srv/shiny-server/atlas/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN pip install pandas
 
 # Install R packages
 RUN R -e 'install.packages(c("plotly", "igraph", "Seurat", "Matrix", "SeuratObject", "DT", "ggplot2", "dplyr", "stringr", "shiny", "shinymanager", "shinyWidgets", "bslib", "shinycssloaders", "bsicons", "VAM", "periscope2", "shinyjs", "tidyr", "DBI", "RSQLite", "jpeg", "png", "qs2", "BiocManager", "remotes"))' && \
-    R -e 'BiocManager::install("ComplexHeatmap", ask = FALSE, update = FALSE)' && \
-    R -e 'remotes::install_github("jinworks/CellChat", dependencies = TRUE, upgrade = "never")'
+    R -e 'BiocManager::install(c("ComplexHeatmap", "BiocNeighbors", "Biobase"), ask = FALSE, update = FALSE)' && \
+    R -e 'remotes::install_github("jinworks/CellChat", dependencies = TRUE, upgrade = "never", force = TRUE)' && \
+    R -e 'stopifnot(requireNamespace("CellChat", quietly = TRUE))'
 
 # Copy Shiny app code
 COPY ./app_code/ /srv/shiny-server/atlas/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ The app prints its working directory to stderr on startup, so you can confirm it
 
 > **Note:** `LOCAL_DEV` only disables authentication for local development. When unset (the default in Docker / production), the UI is wrapped with `shinymanager` and the SQLite credential database is required as normal.
 
+### CellChat data
+
+The CellChat tab is enabled only for studies with a complete CellChat entry in
+[app_code/config/dataset_details.json](app_code/config/dataset_details.json).
+The initial Tabib integration expects these precomputed, stripped CellChat
+objects in the study data directory:
+
+```
+app_code/data/tabib/cellchat/merged.rds
+app_code/data/tabib/cellchat/HC.rds
+app_code/data/tabib/cellchat/SSc.rds
+```
+
+For deployment, copy the same directory structure to the mounted EC2 data
+volume under `tabib/cellchat/`. These objects are data assets and must not be
+committed to the repository. The CellChat tab displays a load error if one is
+missing or invalid.
+
 ### Pull Request Deployment
 
 All pull requests to the `main` branch are **automatically deployed to EC2** for manual testing. This allows you to test the full UI and backend functionality in a real environment before merging.

--- a/app_code/config/dataset_details.json
+++ b/app_code/config/dataset_details.json
@@ -45,6 +45,13 @@
     },
     "files": {
       "meta": "Tabib_metadata.txt",
+      "cellchat": {
+        "merged": "cellchat/merged.rds",
+        "conditions": {
+          "HC": "cellchat/HC.rds",
+          "SSc": "cellchat/SSc.rds"
+        }
+      },
       "full": {
         "seurat": "Tabib_full_filtered_VAM.rds",
         "gene_list": "Tabib_gene_list.rds",

--- a/app_code/modules/cellchat_explorer_module.R
+++ b/app_code/modules/cellchat_explorer_module.R
@@ -1,0 +1,241 @@
+library(shiny)
+library(bslib)
+library(DT)
+
+# ---------- MODULE UI ----------
+cellchat_explorer_UI <- function(id, choices) {
+  ns <- NS(id)
+
+  layout_sidebar(
+    sidebar = sidebar(
+      title = "CellChat options",
+      selectInput(ns("study"), "Select study", choices = choices),
+      radioButtons(
+        ns("measure"), "Aggregate measure",
+        choices = c("Strength" = "weight", "Count" = "count"),
+        selected = "weight", inline = TRUE
+      ),
+      selectInput(ns("condition"), "Condition for drill-down", choices = NULL),
+      tags$hr(),
+      tags$strong("Filters"),
+      selectizeInput(
+        ns("sources"), "Source cell type(s)", choices = NULL, multiple = TRUE,
+        options = list(placeholder = "All")
+      ),
+      selectizeInput(
+        ns("targets"), "Target cell type(s)", choices = NULL, multiple = TRUE,
+        options = list(placeholder = "All")
+      ),
+      selectizeInput(
+        ns("pathways"), "Pathway(s)", choices = NULL, multiple = TRUE,
+        options = list(placeholder = "All")
+      ),
+      textInput(ns("ligand"), "Ligand contains", ""),
+      textInput(ns("receptor"), "Receptor contains", ""),
+      sliderInput(ns("prob_min"), "Minimum probability", 0, 1, 0, step = 0.01),
+      sliderInput(ns("pval_max"), "Maximum p-value", 0, 1, 1, step = 0.01)
+    ),
+    tagList(
+      uiOutput(ns("status")),
+      navset_tab(
+        nav_panel(
+          "Comparison overview",
+          p("Aggregated interactions per condition, differential interactions, and total comparison."),
+          plotOutput(ns("circle"), height = "460px"),
+          layout_columns(
+            col_widths = c(6, 6),
+            card(card_header("Differential interactions"), plotOutput(ns("diff"), height = "400px")),
+            card(card_header("Total interactions"), plotOutput(ns("compare"), height = "400px"))
+          )
+        ),
+        nav_panel(
+          "Heatmaps",
+          radioButtons(
+            ns("role_pattern"), "Signaling role pattern",
+            choices = c("Outgoing" = "outgoing", "Incoming" = "incoming", "Overall" = "all"),
+            selected = "outgoing", inline = TRUE
+          ),
+          plotOutput(ns("heatmap_diff"), height = "460px"),
+          plotOutput(ns("heatmap_role"), height = "560px")
+        ),
+        nav_panel(
+          "L-R bubble",
+          p("Ligand-receptor pairs across selected source and target cell types."),
+          plotOutput(ns("bubble"), height = "720px")
+        ),
+        nav_panel(
+          "Signaling roles / rankNet",
+          checkboxInput(ns("rank_stacked"), "Stacked (absolute) rankNet", value = TRUE),
+          plotOutput(ns("ranknet"), height = "640px"),
+          plotOutput(ns("role_scatter"), height = "480px")
+        ),
+        nav_panel(
+          "Communication table",
+          radioButtons(
+            ns("level"), "Resolution",
+            choices = c("Ligand-receptor" = "LR", "Pathway" = "pathway"),
+            selected = "LR", inline = TRUE
+          ),
+          downloadButton(ns("download"), "Download filtered CSV"),
+          br(), br(),
+          DTOutput(ns("table"))
+        )
+      )
+    )
+  )
+}
+
+# ---------- MODULE SERVER ----------
+cellchat_explorer_server <- function(id, dataset_configs, gallery_selection = NULL) {
+  moduleServer(id, function(input, output, session) {
+    selected_study <- reactive({ input$study })
+
+    if (!is.null(gallery_selection)) {
+      observeEvent(gallery_selection(), {
+        selection <- gallery_selection()
+        if (is.list(selection) && identical(selection$view, "cellchat") &&
+            selection$id %in% names(dataset_configs)) {
+          updateSelectInput(session, "study", selected = selection$id)
+        }
+      }, ignoreInit = TRUE)
+    }
+
+    cellchat_data <- reactive({
+      study <- selected_study()
+      req(study, study %in% names(dataset_configs))
+      cellchat_load_objects(study, dataset_configs[[study]])
+    })
+
+    output$status <- renderUI({
+      data <- cellchat_data()
+      if (!is.null(data$error)) {
+        div(class = "alert alert-danger", role = "alert", data$error)
+      } else {
+        NULL
+      }
+    })
+
+    observeEvent(cellchat_data(), {
+      data <- cellchat_data()
+      if (!is.null(data$error)) {
+        updateSelectInput(session, "condition", choices = character())
+        updateSelectizeInput(session, "sources", choices = character(), selected = character())
+        updateSelectizeInput(session, "targets", choices = character(), selected = character())
+        updateSelectizeInput(session, "pathways", choices = character(), selected = character())
+        return()
+      }
+
+      conditions <- names(data$conditions)
+      updateSelectInput(
+        session, "condition", choices = conditions,
+        selected = conditions[[1]] %||% NULL
+      )
+      celltypes <- cellchat_celltypes(data$merged)
+      pathways <- cellchat_pathways(data$merged)
+      updateSelectizeInput(session, "sources", choices = celltypes, selected = character())
+      updateSelectizeInput(session, "targets", choices = celltypes, selected = character())
+      updateSelectizeInput(session, "pathways", choices = pathways, selected = character())
+    }, ignoreInit = FALSE)
+
+    selected_condition_object <- reactive({
+      data <- cellchat_data()
+      req(is.null(data$error), input$condition)
+      data$conditions[[input$condition]]
+    })
+
+    draw_plot <- function(plot_function) {
+      data <- cellchat_data()
+      if (!is.null(data$error)) {
+        cellchat_draw_plot_error(data$error)
+        return(invisible(NULL))
+      }
+      tryCatch(
+        plot_function(data),
+        error = function(error) {
+          cellchat_draw_plot_error(paste("CellChat plot could not be generated:",
+                                         conditionMessage(error)))
+        }
+      )
+    }
+
+    output$circle <- renderPlot({
+      draw_plot(function(data) {
+        cellchat_plot_circle_comparison(data$merged, input$measure)
+      })
+    })
+    output$diff <- renderPlot({
+      draw_plot(function(data) {
+        cellchat_plot_diff_interaction(data$merged, input$measure)
+      })
+    })
+    output$compare <- renderPlot({
+      draw_plot(function(data) {
+        cellchat_plot_compare_interactions(data$merged, input$measure)
+      })
+    })
+    output$heatmap_diff <- renderPlot({
+      draw_plot(function(data) {
+        cellchat_plot_heatmap_diff(data$merged, input$measure)
+      })
+    })
+    output$heatmap_role <- renderPlot({
+      draw_plot(function(data) {
+        object <- selected_condition_object()
+        req(object)
+        cellchat_plot_signaling_role_heatmap(object, input$role_pattern, input$pathways)
+      })
+    })
+    output$bubble <- renderPlot({
+      draw_plot(function(data) {
+        cellchat_plot_bubble(data$merged, input$sources, input$targets, input$pathways)
+      })
+    })
+    output$ranknet <- renderPlot({
+      draw_plot(function(data) {
+        cellchat_plot_ranknet(data$merged, input$rank_stacked)
+      })
+    })
+    output$role_scatter <- renderPlot({
+      draw_plot(function(data) {
+        object <- selected_condition_object()
+        req(object)
+        cellchat_plot_signaling_role_scatter(object, input$pathways)
+      })
+    })
+
+    communication_table <- reactive({
+      data <- cellchat_data()
+      if (!is.null(data$error)) return(tibble::tibble())
+      cellchat_extract_comm(data$merged, input$level)
+    })
+
+    filtered_table <- reactive({
+      cellchat_apply_comm_filters(
+        communication_table(),
+        sources = input$sources,
+        targets = input$targets,
+        ligand = input$ligand,
+        receptor = input$receptor,
+        pathway = input$pathways,
+        prob_min = input$prob_min,
+        pval_max = input$pval_max
+      )
+    })
+
+    output$table <- renderDT({
+      datatable(
+        filtered_table(), filter = "top",
+        options = list(pageLength = 25, scrollX = TRUE)
+      )
+    })
+
+    output$download <- downloadHandler(
+      filename = function() {
+        paste0("cellchat_", selected_study(), "_", input$level, "_filtered.csv")
+      },
+      content = function(file) {
+        utils::write.csv(filtered_table(), file, row.names = FALSE)
+      }
+    )
+  })
+}

--- a/app_code/modules/cellchat_helpers.R
+++ b/app_code/modules/cellchat_helpers.R
@@ -1,0 +1,278 @@
+# Utilities for loading and visualizing precomputed CellChat results.
+#
+# The app uses stripped CellChat objects that retain network and annotation
+# slots while omitting expression matrices. This keeps the interactive views
+# light enough to load on demand for an individual study.
+
+cellchat_merged_datasets <- function(obj) {
+  if (is.null(obj) || !methods::is(obj, "CellChat")) return(character())
+  net <- obj@net
+  nm <- names(net)
+  if (is.list(net) && length(nm) > 0 && !("count" %in% nm)) nm else character()
+}
+
+cellchat_is_merged <- function(obj) length(cellchat_merged_datasets(obj)) > 0
+
+cellchat_celltypes <- function(obj) {
+  if (is.null(obj) || !methods::is(obj, "CellChat")) return(character())
+  idents <- obj@idents
+  if (is.list(idents) && !is.null(idents$joint)) {
+    levels(idents$joint)
+  } else {
+    levels(idents)
+  }
+}
+
+cellchat_pathways <- function(obj) {
+  if (is.null(obj) || !methods::is(obj, "CellChat")) return(character())
+  netp <- obj@netP
+  if (cellchat_is_merged(obj)) {
+    datasets <- cellchat_merged_datasets(obj)
+    pathways <- unlist(lapply(datasets, function(dataset) {
+      netp[[dataset]]$pathways %||% character()
+    }), use.names = FALSE)
+    sort(unique(pathways))
+  } else {
+    sort(unique(netp$pathways %||% character()))
+  }
+}
+
+cellchat_load_objects <- function(study, config) {
+  empty <- list(merged = NULL, conditions = list(), error = NULL)
+
+  if (!requireNamespace("CellChat", quietly = TRUE)) {
+    empty$error <- "The CellChat package is not available in this app image."
+    return(empty)
+  }
+  if (!cellchat_config_complete(config)) {
+    empty$error <- "This study does not have a complete CellChat configuration."
+    return(empty)
+  }
+
+  read_configured_object <- function(relative_path) {
+    tryCatch(
+      read_object(data_path(study, relative_path)),
+      error = function(error) error
+    )
+  }
+
+  merged <- read_configured_object(config$merged)
+  if (inherits(merged, "error")) {
+    empty$error <- paste("Unable to load the merged CellChat object:", conditionMessage(merged))
+    return(empty)
+  }
+  if (!methods::is(merged, "CellChat") || !cellchat_is_merged(merged)) {
+    empty$error <- "The configured merged object is not a valid multi-condition CellChat object."
+    return(empty)
+  }
+
+  configured_conditions <- config$conditions
+  condition_objects <- lapply(configured_conditions, read_configured_object)
+  failures <- names(condition_objects)[vapply(condition_objects, inherits, logical(1), what = "error")]
+  if (length(failures) > 0) {
+    messages <- vapply(condition_objects[failures], conditionMessage, character(1))
+    empty$error <- paste0(
+      "Unable to load CellChat condition object(s) ",
+      paste(failures, collapse = ", "), ": ",
+      paste(messages, collapse = "; ")
+    )
+    return(empty)
+  }
+  invalid <- names(condition_objects)[!vapply(condition_objects, methods::is, logical(1), class2 = "CellChat")]
+  if (length(invalid) > 0) {
+    empty$error <- paste("Configured condition object(s) are not CellChat objects:",
+                         paste(invalid, collapse = ", "))
+    return(empty)
+  }
+
+  list(merged = merged, conditions = condition_objects, error = NULL)
+}
+
+# ---- Communication table extraction and filtering ---------------------------
+
+cellchat_standardize_comm_columns <- function(data) {
+  if (!is.data.frame(data) || nrow(data) == 0) return(tibble::tibble())
+  out <- tibble::as_tibble(data)
+  candidates <- list(
+    source = c("source", "source.labels", "sender"),
+    target = c("target", "target.labels", "receiver"),
+    ligand = c("ligand", "geneL"),
+    receptor = c("receptor", "geneR"),
+    pathway = c("pathway_name", "pathway", "signaling"),
+    prob = c("prob", "probability", "score"),
+    pval = c("pval", "p.value", "p_value", "pval.adj")
+  )
+
+  for (name in names(candidates)) {
+    match <- candidates[[name]][candidates[[name]] %in% names(out)]
+    if (length(match) > 0 && match[[1]] != name) {
+      names(out)[names(out) == match[[1]]] <- name
+    }
+  }
+  for (name in names(candidates)) {
+    if (!(name %in% names(out))) out[[name]] <- NA
+  }
+
+  out <- dplyr::mutate(
+    out,
+    source = as.character(.data$source),
+    target = as.character(.data$target),
+    ligand = as.character(.data$ligand),
+    receptor = as.character(.data$receptor),
+    pathway = as.character(.data$pathway),
+    prob = suppressWarnings(as.numeric(.data$prob)),
+    pval = suppressWarnings(as.numeric(.data$pval)),
+    pair = ifelse(is.na(.data$ligand) | is.na(.data$receptor), NA_character_,
+                  paste(.data$ligand, .data$receptor, sep = " -> "))
+  )
+
+  preferred <- c("dataset", "source", "target", "ligand", "receptor", "pair",
+                 "pathway", "prob", "pval")
+  out[, c(intersect(preferred, names(out)), setdiff(names(out), preferred)), drop = FALSE]
+}
+
+cellchat_extract_comm <- function(obj, level = c("LR", "pathway")) {
+  level <- match.arg(level)
+  if (is.null(obj) || !requireNamespace("CellChat", quietly = TRUE)) {
+    return(tibble::tibble())
+  }
+  slot_name <- if (level == "pathway") "netP" else "net"
+  raw <- tryCatch(
+    CellChat::subsetCommunication(obj, slot.name = slot_name),
+    error = function(error) NULL
+  )
+  if (is.null(raw)) return(tibble::tibble())
+  if (is.data.frame(raw)) return(cellchat_standardize_comm_columns(raw))
+  if (!is.list(raw)) return(tibble::tibble())
+
+  parts <- lapply(names(raw), function(dataset) {
+    out <- cellchat_standardize_comm_columns(raw[[dataset]])
+    if (nrow(out) > 0) tibble::add_column(out, dataset = dataset, .before = 1) else out
+  })
+  dplyr::bind_rows(parts)
+}
+
+cellchat_contains_pattern <- function(values, pattern) {
+  if (is.null(pattern) || !nzchar(pattern)) return(rep(TRUE, length(values)))
+  stringr::str_detect(
+    tolower(as.character(values)),
+    stringr::fixed(tolower(pattern))
+  )
+}
+
+cellchat_apply_comm_filters <- function(data, sources = NULL, targets = NULL,
+                                        ligand = NULL, receptor = NULL, pathway = NULL,
+                                        prob_min = 0, pval_max = 1) {
+  if (!is.data.frame(data) || nrow(data) == 0) return(tibble::as_tibble(data))
+  out <- data
+  matches_selection <- function(values, selected) {
+    if (is.null(selected) || length(selected) == 0 || identical(selected, "All")) {
+      rep(TRUE, length(values))
+    } else {
+      values %in% selected
+    }
+  }
+
+  out <- out[matches_selection(out$source, sources), , drop = FALSE]
+  out <- out[matches_selection(out$target, targets), , drop = FALSE]
+  out <- out[matches_selection(out$pathway, pathway), , drop = FALSE]
+  out <- out[cellchat_contains_pattern(out$ligand, ligand), , drop = FALSE]
+  out <- out[cellchat_contains_pattern(out$receptor, receptor), , drop = FALSE]
+  out <- out[is.na(out$prob) | out$prob >= prob_min, , drop = FALSE]
+  out <- out[is.na(out$pval) | out$pval <= pval_max, , drop = FALSE]
+  tibble::as_tibble(out)
+}
+
+# ---- Plot wrappers -----------------------------------------------------------
+
+cellchat_selection_or_null <- function(value) {
+  if (is.null(value) || length(value) == 0 || all(!nzchar(value))) NULL else value
+}
+
+cellchat_plot_circle_comparison <- function(merged, measure = c("weight", "count")) {
+  measure <- match.arg(measure)
+  datasets <- cellchat_merged_datasets(merged)
+  matrices <- lapply(datasets, function(dataset) merged@net[[dataset]][[measure]])
+  maximum <- max(vapply(matrices, function(matrix) max(matrix, na.rm = TRUE), numeric(1)))
+  old_parameters <- graphics::par(mfrow = c(1, length(datasets)), xpd = TRUE)
+  on.exit(graphics::par(old_parameters), add = TRUE)
+  for (index in seq_along(datasets)) {
+    CellChat::netVisual_circle(
+      matrices[[index]], weight.scale = TRUE, label.edge = FALSE,
+      edge.weight.max = maximum,
+      title.name = paste0(datasets[[index]], " (", measure, ")")
+    )
+  }
+  invisible(NULL)
+}
+
+cellchat_plot_diff_interaction <- function(merged, measure = c("count", "weight")) {
+  CellChat::netVisual_diffInteraction(
+    merged, weight.scale = TRUE, measure = match.arg(measure)
+  )
+  invisible(NULL)
+}
+
+cellchat_plot_compare_interactions <- function(merged, measure = c("count", "weight")) {
+  plot <- CellChat::compareInteractions(
+    merged, show.legend = FALSE, group = seq_along(cellchat_merged_datasets(merged)),
+    measure = match.arg(measure)
+  )
+  print(plot)
+  invisible(NULL)
+}
+
+cellchat_plot_heatmap_diff <- function(merged, measure = c("count", "weight")) {
+  heatmap <- CellChat::netVisual_heatmap(merged, measure = match.arg(measure))
+  ComplexHeatmap::draw(heatmap)
+  invisible(NULL)
+}
+
+cellchat_plot_signaling_role_heatmap <- function(obj, pattern = c("outgoing", "incoming", "all"),
+                                                  signaling = NULL) {
+  heatmap <- CellChat::netAnalysis_signalingRole_heatmap(
+    obj, pattern = match.arg(pattern), signaling = cellchat_selection_or_null(signaling)
+  )
+  ComplexHeatmap::draw(heatmap)
+  invisible(NULL)
+}
+
+cellchat_plot_bubble <- function(merged, sources = NULL, targets = NULL, signaling = NULL) {
+  plot <- CellChat::netVisual_bubble(
+    merged,
+    sources.use = cellchat_selection_or_null(sources),
+    targets.use = cellchat_selection_or_null(targets),
+    signaling = cellchat_selection_or_null(signaling),
+    comparison = seq_along(cellchat_merged_datasets(merged)),
+    angle.x = 45
+  )
+  print(plot)
+  invisible(NULL)
+}
+
+cellchat_plot_ranknet <- function(merged, stacked = TRUE) {
+  plot <- CellChat::rankNet(
+    merged, mode = "comparison",
+    comparison = seq_along(cellchat_merged_datasets(merged)),
+    stacked = stacked, do.stat = TRUE
+  )
+  print(plot)
+  invisible(NULL)
+}
+
+cellchat_plot_signaling_role_scatter <- function(obj, signaling = NULL) {
+  plot <- CellChat::netAnalysis_signalingRole_scatter(
+    obj, signaling = cellchat_selection_or_null(signaling)
+  )
+  print(plot)
+  invisible(NULL)
+}
+
+cellchat_draw_plot_error <- function(message) {
+  graphics::plot.new()
+  graphics::text(
+    0.5, 0.5,
+    labels = paste(strwrap(message, width = 70), collapse = "\n"),
+    cex = 1.1
+  )
+}

--- a/app_code/modules/dataset_gallery_module.R
+++ b/app_code/modules/dataset_gallery_module.R
@@ -20,7 +20,7 @@ dataset_gallery_UI <- function(id) {
 }
 
 # ---------- MODULE SERVER ----------
-dataset_gallery_server <- function(id) {
+dataset_gallery_server <- function(id, cellchat_dataset_ids = character()) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -79,6 +79,13 @@ dataset_gallery_server <- function(id) {
           action_buttons <- list(actionButton(ns(paste0("explore_spatial_", row$id)), "View Spatial"))
         }
 
+        if (row$id %in% cellchat_dataset_ids) {
+          action_buttons <- append(
+            action_buttons,
+            list(actionButton(ns(paste0("explore_cellchat_", row$id)), "View CellChat"))
+          )
+        }
+
         tags$div(
           class = "dataset-card",
           tags$img(src = row$image, class = "dataset-img", alt = row$name),
@@ -103,6 +110,13 @@ dataset_gallery_server <- function(id) {
       # Observer for Spatial button
       observeEvent(input[[paste0("explore_spatial_", id)]], {
         selected_study(list(id = id, view = "spatial"))
+      })
+    })
+
+    # CellChat buttons are generated only for studies with complete CellChat data.
+    lapply(cellchat_dataset_ids, function(id) {
+      observeEvent(input[[paste0("explore_cellchat_", id)]], {
+        selected_study(list(id = id, view = "cellchat"))
       })
     })
 

--- a/app_code/server.R
+++ b/app_code/server.R
@@ -18,6 +18,8 @@ source("setup.R")
 source("modules/dataset_gallery_module.R")
 source("modules/explore_sidebar_module.R")
 source("modules/spatial_unit.R")
+source("modules/cellchat_helpers.R")
+source("modules/cellchat_explorer_module.R")
 
 options(shiny.trace = FALSE)
 
@@ -82,7 +84,19 @@ server <- function(input, output, session) {
 
   options(shiny.trace = FALSE, shiny.fullstacktrace = FALSE, shiny.sanitize.errors = TRUE)
 
-  selected_study_from_gallery <- dataset_gallery_server("gallery_module")
+  selected_study_from_gallery <- dataset_gallery_server(
+    "gallery_module",
+    cellchat_dataset_ids = cellchat_dataset_ids
+  )
+
+  cellchat_explorer_server(
+    "cellchat_module",
+    dataset_configs = lapply(
+      dataset_files[cellchat_dataset_ids],
+      function(files) files$cellchat
+    ),
+    gallery_selection = selected_study_from_gallery
+  )
 
   sidebar_inputs <- explore_sidebar_server("explore_sidebar_module", 
                                            selected_study_from_gallery = selected_study_from_gallery)
@@ -101,6 +115,10 @@ server <- function(input, output, session) {
         nav_select("nav_page", selected = "spatial")
         # Update the study selector on the spatial page
         updateSelectInput(session, "spatial_study_selector", selected = study_info$id)
+      } else if (study_info$view == "cellchat") {
+        # The CellChat module receives the same selection and updates its own
+        # namespaced study input before its visualizations render.
+        nav_select("nav_page", selected = "cellchat")
       }
     } else {
       # Fallback for old behavior or unexpected data

--- a/app_code/setup.R
+++ b/app_code/setup.R
@@ -40,6 +40,17 @@ read_object <- function(path) {
   readRDS(path)
 }
 
+cellchat_config_complete <- function(config) {
+  if (is.null(config) || !is.list(config)) return(FALSE)
+  merged <- config$merged %||% ""
+  conditions <- config$conditions
+  is.character(merged) && length(merged) == 1 && nzchar(merged) &&
+    is.list(conditions) && length(conditions) > 0 &&
+    all(vapply(conditions, function(path) {
+      is.character(path) && length(path) == 1 && nzchar(path)
+    }, logical(1)))
+}
+
 cat("Working directory is:", getwd(), "\n", file = stderr())
 
 # Default comparison metadata for datasets without explicit configuration
@@ -110,3 +121,13 @@ scrna_dataset_choices <- setNames(
   dataset_meta$id[dataset_meta$has_scrna],
   dataset_meta$name[dataset_meta$has_scrna]
 )
+
+# Studies with a complete, precomputed CellChat comparison. The CellChat tab
+# and gallery entry points use this list so unavailable datasets are never
+# presented as selectable CellChat studies.
+cellchat_dataset_ids <- names(dataset_files)[vapply(
+  dataset_files,
+  function(files) cellchat_config_complete(files$cellchat),
+  logical(1)
+)]
+cellchat_dataset_choices <- dataset_choices[dataset_choices %in% cellchat_dataset_ids]

--- a/app_code/ui.R
+++ b/app_code/ui.R
@@ -28,6 +28,8 @@ source("setup.R")
 source("modules/spatial_unit.R")
 source("modules/dataset_gallery_module.R")
 source("modules/explore_sidebar_module.R")
+source("modules/cellchat_helpers.R")
+source("modules/cellchat_explorer_module.R")
 
 
 # Feature plot of queried genes
@@ -191,6 +193,14 @@ ui <- page_navbar(
             ),
   ),
   
+  nav_panel(
+    "CellChat",
+    value = "cellchat",
+    bslib::page_fluid(
+      cellchat_explorer_UI("cellchat_module", choices = cellchat_dataset_choices)
+    )
+  ),
+
   nav_panel("Spatial data explorer",
     value = "spatial",
     bslib::page_fluid(


### PR DESCRIPTION
## Summary
- add a dedicated CellChat explorer with comparison, heatmap, ligand-receptor, signaling-role, and communication-table views
- expose a **View CellChat** gallery action only for studies with configured results, transferring the selected study into the CellChat tab
- configure the existing Tabib HC/SSc processed CellChat objects and document the required mounted data layout
- install the CellChat and ComplexHeatmap runtime dependencies in the application image

## Validation
- parsed all changed R files and validated the JSON configuration
- sourced the complete Shiny app in local development mode
- exercised gallery selection and module missing-data handling with Shiny test helpers
- ran communication-table extraction and all CellChat plot helpers against the standalone demo's processed objects

## Deployment note
The three Tabib CellChat RDS files remain ignored data assets. Copy them to the EC2-mounted `tabib/cellchat/` directory before testing the deployed app.

Docker image build was not run locally because the Docker daemon is unavailable.