### PR TITLE
Fix production deploy abort (pipefail SIGPIPE in image reuse lookup)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,8 +96,12 @@ jobs:
             elif [ "$CURRENT_FP" = "$FP" ]; then
               echo "  ✓ Current tcell_atlas:latest already matches main — no build needed"
             else
-              MATCH=$(docker images --filter "label=atlas.build_fp=${FP}" --format '{{.ID}}' | head -1)
-              if [ -n "${MATCH:-}" ]; then
+              # Grab matching image IDs without a pipe, then take the first line via
+              # parameter expansion. Piping to `head` would SIGPIPE the producer, and
+              # under `set -o pipefail` that non-zero status aborts the whole deploy.
+              MATCHES=$(docker images --filter "label=atlas.build_fp=${FP}" --format '{{.ID}}')
+              MATCH=${MATCHES%%$'\n'*}
+              if [ -n "$MATCH" ]; then
                 echo "  ✓ Reusing existing image $MATCH (fingerprint match, e.g. the PR image)"
                 docker tag "$MATCH" tcell_atlas:latest
               else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,13 @@ jobs:
             # Kill any process using port 80
             sudo lsof -ti:80 | xargs -r sudo kill -9 || true
             
-            # Also check for docker containers on port 80
-            CONTAINER_ID=$(docker ps -a --filter "publish=80" --format "{{.ID}}" | head -1)
-            if [ -n "${CONTAINER_ID:-}" ]; then
+            # Also check for docker containers on port 80. Capture IDs without a
+            # pipe and take the first line via parameter expansion — piping to
+            # `head` would SIGPIPE `docker ps` and, under `set -o pipefail`, abort
+            # the deploy (right after `docker-compose down` took prod down).
+            PORT80_IDS=$(docker ps -a --filter "publish=80" --format "{{.ID}}")
+            CONTAINER_ID=${PORT80_IDS%%$'\n'*}
+            if [ -n "$CONTAINER_ID" ]; then
               echo "  Found container using port 80: $CONTAINER_ID, removing..."
               docker stop "$CONTAINER_ID" || true
               docker rm "$CONTAINER_ID" || true


### PR DESCRIPTION
## Problem

The production deploy after merging #56 **failed**, taking production down: `deploy.yml` runs `docker-compose down` early, then aborted at the image reuse-or-build step *before* `docker-compose up`.

## Root cause

The reuse lookup piped `docker images ... | head -1`. When the fingerprint matches **multiple** images on the host (the expected reuse case — the `atlas:pr-56` image plus others), `head` closes the pipe early, `docker images` gets SIGPIPE (exit 141), and under `set -o pipefail` the `MATCH=$(...)` assignment is non-zero, so `set -e` killed the whole deploy in milliseconds — before any branch echo.

## Fix

Capture the matching IDs without a pipe and take the first line via bash parameter expansion (`${MATCHES%%$'\n'*}`), which cannot SIGPIPE.

Once merged, the deploy should hit the fast reuse path (fingerprint `23bed…` already matches `atlas:pr-56` on the host) — tag + `up`, no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)