### PR TITLE
Fix production deploy: move reuse logic to a script (appleboy mangles inline multiline)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,36 +83,17 @@ jobs:
             echo "🛠 Preparing production image (reuse-or-build-once)..."
             # Fingerprint the only inputs that affect image content: the Dockerfile
             # (drives apt/R/CellChat) and what it COPYs (app_code/ + shiny-server.conf).
-            # Same fingerprint => byte-identical image, so we can safely reuse an
-            # already-built image (e.g. the PR image on this same host) instead of
-            # rebuilding all three containers from scratch.
+            # Same fingerprint => byte-identical image, so scripts/deploy_prepare_image.sh
+            # can reuse an already-built image (e.g. the PR image on this host) instead
+            # of rebuilding all three containers from scratch.
+            #
+            # The reuse/build logic lives in a standalone script and is invoked in ONE
+            # line on purpose: appleboy/ssh-action (script_stop) splits this block by
+            # newline and injects exit-code checks between lines, which corrupts inline
+            # multi-line constructs (if/elif/else, multi-line $()). A single-line call
+            # to a real bash script is immune to that.
             FP=$(git rev-parse HEAD:Dockerfile HEAD:shiny-server.conf HEAD:app_code | git hash-object --stdin)
-            echo "  Build fingerprint: $FP"
-
-            # Fingerprint currently tagged as tcell_atlas:latest, if any. The `|| true`
-            # keeps a missing image / missing label (e.g. the first run after introducing
-            # labels) from tripping `set -e` — it just yields an empty CURRENT_FP.
-            CURRENT_FP=$(docker image inspect tcell_atlas:latest --format '{{index .Config.Labels "atlas.build_fp"}}' 2>/dev/null || true)
-
-            if [ "${{ github.event.inputs.force_rebuild }}" = "true" ]; then
-              echo "  🛠 force_rebuild — full rebuild with a fresh base image"
-              docker build --pull -t tcell_atlas:latest --label "atlas.build_fp=${FP}" .
-            elif [ "$CURRENT_FP" = "$FP" ]; then
-              echo "  ✓ Current tcell_atlas:latest already matches main — no build needed"
-            else
-              # Grab matching image IDs without a pipe, then take the first line via
-              # parameter expansion. Piping to `head` would SIGPIPE the producer, and
-              # under `set -o pipefail` that non-zero status aborts the whole deploy.
-              MATCHES=$(docker images --filter "label=atlas.build_fp=${FP}" --format '{{.ID}}')
-              MATCH=${MATCHES%%$'\n'*}
-              if [ -n "$MATCH" ]; then
-                echo "  ✓ Reusing existing image $MATCH (fingerprint match, e.g. the PR image)"
-                docker tag "$MATCH" tcell_atlas:latest
-              else
-                echo "  🛠 No matching image — building once (layer cache preserved)"
-                docker build -t tcell_atlas:latest --label "atlas.build_fp=${FP}" .
-              fi
-            fi
+            bash scripts/deploy_prepare_image.sh "$FP" "${{ github.event.inputs.force_rebuild }}"
 
             echo "🔐 Setting up environment..."
             echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" > .env

--- a/scripts/deploy_prepare_image.sh
+++ b/scripts/deploy_prepare_image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Prepare the production image tcell_atlas:latest for docker-compose.
+# Reuses an already-built image (e.g. the PR image on this host) whose
+# build-input fingerprint matches, else builds once. Runs as a standalone
+# script so appleboy/ssh-action's line-splitting can't corrupt the logic.
+set -euo pipefail
+
+FP="${1:?fingerprint required}"
+FORCE_REBUILD="${2:-false}"
+IMAGE="tcell_atlas:latest"
+
+echo "  Build fingerprint: $FP"
+
+if [ "$FORCE_REBUILD" = "true" ]; then
+  echo "  force_rebuild — full rebuild with a fresh base image"
+  docker build --pull -t "$IMAGE" --label "atlas.build_fp=$FP" .
+  exit 0
+fi
+
+# First image (incl. current latest) whose label matches this fingerprint.
+REUSE_ID="$(docker images --filter "label=atlas.build_fp=$FP" --format '{{.ID}}' | head -n1 || true)"
+
+if [ -n "$REUSE_ID" ]; then
+  echo "  Reusing image $REUSE_ID (fingerprint match)"
+  docker tag "$REUSE_ID" "$IMAGE"
+else
+  echo "  No matching image — building once (layer cache preserved)"
+  docker build -t "$IMAGE" --label "atlas.build_fp=$FP" .
+fi


### PR DESCRIPTION
## Root cause (finally pinned down via SSH to the host)

Every production deploy since #56 aborted at the *same* spot — right after the `Build fingerprint:` echo, with no error — regardless of which inline fix I applied. Running the **exact same block** directly on the EC2 host works perfectly. The difference is the executor: `appleboy/ssh-action` with `script_stop: true` splits the `script:` block by newline and injects exit-code checks between lines, which **corrupts inline multi-line constructs** (the reuse `if/elif/else`, multi-line `$()`). So the pipefail/SIGPIPE fixes were treating symptoms — the real problem is inline multi-line shell under appleboy.

## Fix

Move the reuse-or-build-once logic into `scripts/deploy_prepare_image.sh` and call it in **one line** from the workflow. A single-line invocation can't be split, and the script runs as normal bash with full multi-line support.

Verified end-to-end on the host: it finds the fingerprint-matched PR image (`atlas:pr-57`) and tags it `tcell_atlas:latest` — no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)